### PR TITLE
Build older manylinux wheels

### DIFF
--- a/.github/workflows/build_manylinux_wheels.yml
+++ b/.github/workflows/build_manylinux_wheels.yml
@@ -1,0 +1,34 @@
+name: Build manylinux wheels
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  mkl-service:
+    uses: ./.github/workflows/wheels.yml
+    with:
+      name: mkl-service
+      repo: IntelPython/mkl-service
+      force-build: true
+      manylinux: true
+
+  numpy:
+    uses: ./.github/workflows/wheels.yml
+    with:
+      name: numpy
+      repo: numpy/numpy
+      force-build: true
+      manylinux: true
+    needs: mkl-service
+
+  scipy:
+    uses: ./.github/workflows/wheels.yml
+    with:
+      name: scipy
+      repo: scipy/scipy
+      force-build: true
+      manylinux: true
+    needs: [mkl-service, numpy]

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -15,6 +15,10 @@ on:
         required: false
         type: boolean
         description: "Force build even if wheels exist"
+      manylinux:
+        required: false
+        type: boolean
+        description: "Build Linux wheels in manylinux container"
       version:
         required: false
         type: string
@@ -52,9 +56,10 @@ jobs:
 
       - name: Fetch build matrix
         run: |
-          ${{ inputs.force-build }} && extra_args="--force-build"
-          MATRIX="$(uv run tools/fetch_matrix ${{ inputs.name }} ${extra_args} \
-            --store build.json --runs-on ubuntu-22.04 --runs-on windows-2019)"
+          fetch_args="--store build.json --runs-on ubuntu-22.04"
+          ${{ inputs.manylinux }} || fetch_args="${fetch_args} --runs-on windows-2019"
+          ${{ inputs.force-build }} && fetch_args="${fetch_args} --force-build"
+          MATRIX="$(uv run tools/fetch_matrix ${{ inputs.name }} ${fetch_args})"
           echo "MATRIX=${MATRIX}" >>$GITHUB_ENV
           echo "${MATRIX}" | yq -P -o yaml
 
@@ -72,7 +77,7 @@ jobs:
     runs-on: ${{ matrix.runs-on }}
 
     container:
-      ${{ matrix.runs-on == 'ubuntu-22.04' && 'quay.io/pypa/manylinux_2_28_x86_64' || null }}
+      ${{ fromJSON(inputs.manylinux) && 'quay.io/pypa/manylinux_2_28_x86_64' || null }}
 
     continue-on-error: true
 
@@ -186,16 +191,14 @@ jobs:
           esac
         if: runner.os == 'windows'
 
-      - name: Install Linux build dependencies
+      - name: Install manylinux build dependencies
         run: |
-          # Use fall-through operator ';&' to match all cases.
           case "${{ inputs.name }}" in
             mkl-service)
-              # Manylinux 2.28 doesn't come with clang.
               dnf -y install clang
               ;&
           esac
-        if: runner.os == 'linux'
+        if: inputs.manylinux
 
       - name: Build wheel
         working-directory: ${{ env.SRC_DIR }}

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -186,6 +186,17 @@ jobs:
           esac
         if: runner.os == 'windows'
 
+      - name: Install Linux build dependencies
+        run: |
+          # Use fall-through operator ';&' to match all cases.
+          case "${{ inputs.name }}" in
+            mkl-service)
+              # Manylinux 2.28 doesn't come with clang.
+              dnf -y install clang
+              ;&
+          esac
+        if: runner.os == 'linux'
+
       - name: Build wheel
         working-directory: ${{ env.SRC_DIR }}
         run: |

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -71,6 +71,9 @@ jobs:
 
     runs-on: ${{ matrix.runs-on }}
 
+    container:
+      ${{ matrix.runs-on == 'ubuntu-22.04' && 'quay.io/pypa/manylinux_2_28_x86_64' || null }}
+
     continue-on-error: true
 
     defaults:

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -105,10 +105,10 @@ jobs:
           # Move src to avoid pyproject conflicts. SRC_DIR is set relative to GITHUB_WORKSPACE to
           # preserve the "D:\" prefix on Windows. (Pure Linux paths aren't supported as arguments
           # to 'working-directory'.)
-          mv src ../../ && echo "SRC_DIR=${{ github.workspace }}/../../src" >>$GITHUB_ENV
+          mv src ../../ && echo "SRC_DIR=${GITHUB_WORKSPACE}/../../src" >>$GITHUB_ENV
 
           # Keep MKL directory short as it ends up in the final build.
-          echo "MKL_DIR=$(realpath "${{ github.workspace }}"/../../mkl)" >>$GITHUB_ENV
+          echo "MKL_DIR=$(realpath "${GITHUB_WORKSPACE}"/../../mkl)" >>$GITHUB_ENV
 
       - name: Install uv
         uses: astral-sh/setup-uv@v5
@@ -132,7 +132,7 @@ jobs:
 
           # Fetch MKL license.
           cat "$(python tools/get_file_in_pkg LICENSE.txt --pkg mkl-devel)" \
-              >>"${{ github.workspace }}/patches/LICENSE_MKL.txt"
+              >>"${GITHUB_WORKSPACE}/patches/LICENSE_MKL.txt"
 
           # Add .so -> .so.2 symlinks to fix linking for mkl-service.
           cd "${{ env.MKL_DIR }}"/lib
@@ -155,18 +155,18 @@ jobs:
           echo "----" >>LICENSE.txt
           echo "" >>LICENSE.txt
           cat LICENSES_bundled.txt >>LICENSE.txt
-          cat "${{ github.workspace }}/patches/LICENSE_MKL.txt" >>LICENSE.txt
+          cat "${GITHUB_WORKSPACE}/patches/LICENSE_MKL.txt" >>LICENSE.txt
         if: inputs.name != 'mkl-service'
 
       - name: Apply patches
         run: |
           # Apply patches.
           cd "${{ env.SRC_DIR }}"
-          git apply "${{ github.workspace }}"/patches/${{ inputs.name }}/*.patch
+          git apply "${GITHUB_WORKSPACE}"/patches/${{ inputs.name }}/*.patch
 
           # Fix MKL pkg-config on Windows.
           if [[ "${{ runner.os }}" == "Windows" ]]; then
-            cp "${{ github.workspace }}"/patches/mkl/*.pc "${PKG_CONFIG_PATH}/"
+            cp "${GITHUB_WORKSPACE}"/patches/mkl/*.pc "${PKG_CONFIG_PATH}/"
           fi
 
       - name: Install Windows build dependencies


### PR DESCRIPTION
Add additional workflow to build linux wheels in manylinux container for compatibility with manylinux_2_28 and later. The default wheels build with ubuntu 22.04 are only compatible with manylinux_2_35 and later.